### PR TITLE
Fix shebang for wider OS compatibility

### DIFF
--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error and unset variables
 set -eu

--- a/tools/update_kurohouou_profiles/update_kurohouou_profiles.sh
+++ b/tools/update_kurohouou_profiles/update_kurohouou_profiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: ./update_kurohouou_profiles.sh /path/to/SD_Card /path/to/update.zip
 

--- a/tools/update_wobling_profiles/update_wobling_profiles.sh
+++ b/tools/update_wobling_profiles/update_wobling_profiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: ./update_wobling_profiles.sh /path/to/SD_Card /path/to/update.zip
 


### PR DESCRIPTION
Some OSes (FreeBSD, for example) don't have `bash` in `/bin`.  This expands compatibility to work on OSes that have it in a different location.