### PR TITLE
Explicitly set writable bit on files and directories in temp dir

### DIFF
--- a/tools/update_kurohouou_profiles/update_kurohouou_profiles.sh
+++ b/tools/update_kurohouou_profiles/update_kurohouou_profiles.sh
@@ -26,6 +26,7 @@ unzip -o "$ZIP_FILE" "image/*" -d "$SD_CARD_PATH"
 echo "Copying 'profile' folder contents from the zip file to '$SD_CARD_PATH/profile/_CRT Emulation'..."
 TEMP_DIR=$(mktemp -d)
 unzip -o "$ZIP_FILE" "profile/*" -d "$TEMP_DIR"
+find "$TEMP_DIR" -exec chmod u+w "{}" \;
 mkdir -p "$SD_CARD_PATH/profile/_CRT Emulation"
 mv "$TEMP_DIR/profile/"* "$SD_CARD_PATH/profile/_CRT Emulation/"
 rm -rf "$TEMP_DIR"


### PR DESCRIPTION
It seems that macOS isn't setting the writable bit on user, group, or other for files and directories that are unzipped directly into the temp directory.  Because of that, this was returning a lot of permissions errors with the `mv` and `rm` commands towards the end.

It's definitely odd behavior, and I'm not sure why it's the case, but it's easy enough to resolve by explicitly setting the user writable bit on everything in the temp directory.  This should be effectively a no-op on other OSes, but it does fix the ability to run it on macOS.