### PR TITLE
Feature/dv1 hdmi input override

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
 - **Default MiSTer Path and SSH User**: Assumes default MiSTer path `/media/fat/` and SSH user `root` if not specified.
 - **Customizable Base Profiles**: Allows you to specify base profiles for different core types.
 - **Per-Core Profile Overrides**: Supports custom per-core profiles through an override script (`profiles_config.sh`). The script includes predefined entries for all available MiSTer cores, making it easy to customize profiles by uncommenting the respective lines.
-- **Profile HDMI Input Override (Placeholder)**: A placeholder feature is included for setting the HDMI input for all DV1 profiles. This is currently not implemented and will be updated in future versions.
+- **Profile HDMI Input Override**: Allows setting the HDMI input for all DV1 profiles to ensure compatibility with the RetroTINK 4K. This feature can be enabled with the `--set-hdmi-input` option.
 - **Additional Arcade Profiles**: Processes additional arcade profiles listed in a text file.
 - **Force Overwrite**: Option to forcefully recreate and overwrite existing profiles with the `--force` flag.
 - **Special Case Handling**: Includes specific handling for certain cores like GBA, GBC, and menu cores.
@@ -94,6 +94,7 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
 - `-r`, `--rt4k PATH` : Set RetroTINK 4K SD card root path.
 - `-m`, `--mister PATH` : Set MiSTer root path (local path or SSH URL).
 - `-f`, `--force` : Force overwrite of existing profiles.
+- `-i`, `--set-hdmi-input` : Enable HDMI input override in profiles.
 
 ## Examples
 
@@ -134,7 +135,12 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
    ./generate_rt4k_mister_dv1_profiles.sh --force
    ```
 
-8. **Display Help Message**:
+8. **Set HDMI Input for All Profiles**:
+   ```bash
+   ./generate_rt4k_mister_dv1_profiles.sh --set-hdmi-input
+   ```
+
+9. **Display Help Message**:
    ```bash
    ./generate_rt4k_mister_dv1_profiles.sh --help
    ```
@@ -181,7 +187,7 @@ To create per-core profile overrides, edit `profiles_config.sh` and add or uncom
 # Define per-core profiles override
 PRF_NES="${RT4K}profile/Nintendo NES + FC/FirebrandX HDRV-Low NTSC/NES DAR 09x.rt4"
 PRF_SNES="${RT4K}profile/Nintendo SNES + SFC/Wobbling Pixels NTSC & PAL RGBL - Sharp/SNES & SFC DAR - Sharp.rt4"
-PRF_GENESIS="${RT4K}profile/Sega Genesis & Mega Drive/Wobbling Pixels NTSC & PAL RGBL - Sharp/Genesis & MD DAR - Sharp.rt4"
+PRF_MEGADRIVE="${RT4K}profile/Sega Genesis & Mega Drive/Wobbling Pixels NTSC & PAL RGBL - Sharp/Genesis & MD DAR - Sharp.rt4"
 
 # Predefined cores (initially commented out for easy customization)
 # Uncomment and specify the desired profile
@@ -221,6 +227,18 @@ The script will generate `.rt4` profile files in the following directory:
 
 - **Verbose Mode**: Use the `--verbose` or `-v` option to enable detailed output of the script’s actions.
 - **Error Messages**: Any errors encountered will be displayed in the console, regardless of the verbosity setting.
+
+## HDMI Input Override
+
+The **HDMI Input Override** feature is used to set the HDMI input in the generated `.rt4` profiles, ensuring compatibility with the RetroTINK 4K device. You can enable this feature by using the `--set-hdmi-input` or `-i` option when running the script. When enabled, the script will modify each profile to specify HDMI as the input source.
+
+This is particularly useful if your RetroTINK 4K setup requires all profiles to default to HDMI input for seamless operation with the MiSTer FPGA.
+
+Example:
+
+```bash
+./generate_rt4k_mister_dv1_profiles.sh --set-hdmi-input
+```
 
 ## SSH Key-Based Authentication Setup on MiSTer
 
@@ -329,7 +347,7 @@ Contributions are welcome! Please open an issue or submit a pull request if you 
 - [x] Feature: add SSH remote retrieval of the core names on the MiSTer (allows execution without removing the SD card from the MiSTer)
 - [x] Feature: Add DV1 Arcade profiles management. Read MiSTer MRA file and create DV1 Arcade list based on `<setname>` (e.g., `sfa2.zip` > `sfa2.rt4`)
 - [x] Feature: Add override profiles option
-- [ ] Feature: Add automatic DV1 profile input set to HDMI
+- [x] Feature: Add automatic DV1 profile input set to HDMI
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
 - **Default MiSTer Path and SSH User**: Assumes default MiSTer path `/media/fat/` and SSH user `root` if not specified.
 - **Customizable Base Profiles**: Allows you to specify base profiles for different core types.
 - **Per-Core Profile Overrides**: Supports custom per-core profiles through an override script (`profiles_config.sh`). The script includes predefined entries for all available MiSTer cores, making it easy to customize profiles by uncommenting the respective lines.
-- **Profile HDMI Input Override**: Allows setting the HDMI input for all DV1 profiles to ensure compatibility with the RetroTINK 4K. This feature can be enabled with the `--set-hdmi-input` option.
+- **Profile HDMI Input Override**: Allows setting the HDMI input for all DV1 profiles to ensure compatibility with the RetroTINK 4K. This feature can be enabled with the `--set-hdmi-input` option. If Python3 is installed, the HDMI input override is performed using a Python script for faster execution; otherwise, it falls back to a slower Bash implementation.
 - **Additional Arcade Profiles**: Processes additional arcade profiles listed in a text file.
 - **Force Overwrite**: Option to forcefully recreate and overwrite existing profiles with the `--force` flag.
 - **Special Case Handling**: Includes specific handling for certain cores like GBA, GBC, and menu cores.
@@ -59,6 +59,7 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
   - **Kuro Houou Profiles**: [Google Drive Link](https://drive.google.com/drive/folders/1zxQqn36P6QPx3mu83SuNplTbbwID1YA2)
   - **Wobbling Pixels Profiles**: [Google Drive Link](https://drive.google.com/drive/folders/1vMn27wOXiCCT9tSqCKr89IhdP3nXP-V5)
 - **MiSTer FPGA**: Up-to-date SD card with the latest core updates.
+- **Python 3**: Optional, recommended for faster execution of the HDMI input override feature.
 
 ## Installation
 
@@ -139,6 +140,8 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
    ```bash
    ./generate_rt4k_mister_dv1_profiles.sh --set-hdmi-input
    ```
+
+   Note: If Python3 is available, this operation will be executed using Python (fast). If Python3 is not installed, a Bash implementation (slow) will be used.
 
 9. **Display Help Message**:
    ```bash
@@ -232,7 +235,9 @@ The script will generate `.rt4` profile files in the following directory:
 
 The **HDMI Input Override** feature is used to set the HDMI input in the generated `.rt4` profiles, ensuring compatibility with the RetroTINK 4K device. You can enable this feature by using the `--set-hdmi-input` or `-i` option when running the script. When enabled, the script will modify each profile to specify HDMI as the input source.
 
-This is particularly useful if your RetroTINK 4K setup requires all profiles to default to HDMI input for seamless operation with the MiSTer FPGA.
+If **Python3** is installed, the HDMI input override will be executed using a Python script, providing a **faster** and more efficient method of modification. If Python3 is **not available**, the script will fall back to a Bash implementation, which is slower but still effective.
+
+This feature is particularly useful if your RetroTINK 4K setup requires all profiles to default to HDMI input for seamless operation with the MiSTer FPGA.
 
 Example:
 
@@ -247,7 +252,7 @@ This will allow you to SSH into your MiSTer without typing a password each time.
 
 ### Setting Up SSH Key-Based Authentication on MiSTer
 For better security, it’s recommended to generate the SSH key pair on your local machine and copy the public key to the MiSTer device.
-If you are familiar with ssh, please also define a pathphrase to be more secure.
+If you are familiar with ssh, please also define a passphrase to be more secure.
 
 #### Prerequisites
 
@@ -262,7 +267,7 @@ If you are familiar with ssh, please also define a pathphrase to be more secure.
    ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
    ```
 
-2. **When prompted, write it to a specific path and let the pathphrase empty**
+2. **When prompted, write it to a specific path and let the passphrase empty**
    ```bash
    ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
    Generating public/private rsa key pair.
@@ -295,7 +300,7 @@ If you are familiar with ssh, please also define a pathphrase to be more secure.
    ssh mister
    ```
 
-5. **Now you can run the tool simply like this (assuming the IP of your mister does not change ;)**
+5. **Now you can run the tool simply like this (assuming the IP of your MiSTer does not change ;))**
    ```bash
    ./generate_rt4k_mister_dv1_profiles.sh --verbose -m ssh://mister
    ```
@@ -362,3 +367,4 @@ This project is licensed under the MIT License. See the LICENSE file for details
 ## Contact
 
 For questions, suggestions, or support, please open an issue on the GitHub repository.
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
 - **Verbose Output**: Optional verbose mode for detailed logging.
 - **Error Handling**: Checks for missing files and directories, providing meaningful error messages.
 
+## MiSTer DV1 Mode and RetroTINK-4K
+
+The RetroTINK-4K is compatible with the MiSTer's DirectVideo (aka DV1) video output mode. Compatible cores can output DV1 video over HDMI, which aims to preserve the original content's pixel-accurate video. To work within the HDMI standard, DV1 can often require resolution padding (black bars) and pixel multiplication. By including the padding and multiplication info in the HDMI transmission itself (via the HDMI SPD Infoframe), compatible devices can recreate a pixel-accurate image by cropping the frame and decimating any pixel duplication.
+
+**Auto-Decimate**: When set to "Infoframe" (recommended when using DV1), the RetroTINK-4K will use the DV1 infoframe data to set the correct decimation factor. "Measure" will try to guess the best decimation setting based on the characteristics of the image. Auto-Decimate can be disabled by selecting "Off".
+
+**Auto-Crop**: When set to "On", the RetroTINK-4K will use the DV1 infoframe data to automatically crop any black borders. Auto-Crop can be disabled by choosing "Off".
+
+Note that DV1 input can also automatically trigger profile changes, using the Auto Load DV1 Profile function:
+
+- **Auto Load DV1**: Will automatically load a DV1 profile, based on the detected DV1-compatible MiSTer core. Requires the name of the profile to match the core name, and for the profile to be located in the DV1 folder. Example: `sdcard/profile/dv1/core-name.rt4`.
+
+### Typical Use Cases for DV1 Mode with RetroTINK-4K
+
+1. **Automatic Profile Loading per Core**: By utilizing the Auto Load DV1 feature, the RetroTINK-4K can automatically load specific profiles per core. This is especially useful when combined with Scanlines (CRT Simulation) profiles for each machine, ensuring the correct display configuration with pixel-accurate representation through the auto-decimation and auto-crop features.
+
+2. **Vertical (Tate) Mode for Arcade Cores**: Another use case is to automatically switch and activate Tate mode (vertical orientation) for specific arcade cores. This ensures the correct display format without manual intervention.
+
+3. **Profile Overrides for Specific Display Needs**: You can always force a certain profile for a console or core if needed. For example, if you want to use a zoomed-in display or have a different preferred display configuration, the override function allows for complete flexibility.
+
 ## Table of Contents
 
 - [Requirements](#requirements)

--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -7,31 +7,34 @@ set -eu
 # Description: Replicate profiles to MiSTer profiles/DV1/ on RetroTINK 4K
 # Usage: ./generate_rt4k_mister_dv1_profiles.sh [options]
 # Options:
-#   -h, --help          Show help message and exit
-#   -v, --verbose       Enable verbose output
-#   -f, --force         Force overwrite of existing profiles
-#   -r, --rt4k PATH     Set RT4K SD Card root path
-#   -m, --mister PATH   Set MiSTer root path (local path or SSH URL)
+#   -h, --help              Show help message and exit
+#   -v, --verbose           Enable verbose output
+#   -f, --force             Force overwrite of existing profiles
+#   -r, --rt4k PATH         Set RT4K SD Card root path
+#   -m, --mister PATH       Set MiSTer root path (local path or SSH URL)
+#   -i, --set-hdmi-input    Enable HDMI input override in profiles
 
 # Default paths (can be overridden by command-line arguments or environment variables)
 RT4K="${RT4K:-data/rt4k/}"
 MISTER="${MISTER:-data/mister/}"
 VERBOSE=0
 FORCE=0
+SET_HDMI_INPUT=0  # New variable to control HDMI input override
 
 # Function to show help message
 show_help() {
   echo "Usage: $0 [options]"
   echo "Options:"
-  echo "  -h, --help          Show help message and exit"
-  echo "  -v, --verbose       Enable verbose output"
-  echo "  -f, --force         Force overwrite of existing profiles"
-  echo "  -r, --rt4k PATH     Set RT4K SD Card root path"
-  echo "  -m, --mister PATH   Set MiSTer root path (local path or SSH URL)"
+  echo "  -h, --help              Show help message and exit"
+  echo "  -v, --verbose           Enable verbose output"
+  echo "  -f, --force             Force overwrite of existing profiles"
+  echo "  -r, --rt4k PATH         Set RT4K SD Card root path"
+  echo "  -m, --mister PATH       Set MiSTer root path (local path or SSH URL)"
+  echo "  -i, --set-hdmi-input    Enable HDMI input override in profiles"
   echo "Examples:"
-  echo "  $0 --rt4k /media/rt4k/ --mister /media/fat/ --verbose"
-  echo "  $0 --rt4k /media/rt4k/ --mister ssh://192.168.1.100 --verbose"
-  echo "  $0 --rt4k /media/rt4k/ --mister ssh://user@hostname --force --verbose"
+  echo "  $0 --rt4k /media/rt4k/ --mister /media/fat/ --verbose --set-hdmi-input"
+  echo "  $0 --rt4k /media/rt4k/ --mister ssh://192.168.1.100 --verbose --set-hdmi-input"
+  echo "  $0 --rt4k /media/rt4k/ --mister ssh://user@hostname --force --verbose --set-hdmi-input"
 }
 
 # Parse command-line arguments
@@ -51,6 +54,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -f|--force)
       FORCE=1
+      shift
+      ;;
+    -i|--set-hdmi-input)
+      SET_HDMI_INPUT=1
       shift
       ;;
     -h|--help)
@@ -194,11 +201,69 @@ sanitize_var_name() {
   echo "$sanitized"
 }
 
-# Placeholder function to set HDMI input in the profile
+# Function to set HDMI input in the profile and recalculate CRC
 set_hdmi_input() {
   local profile_path="$1"
-  # Placeholder for future implementation
-  # log "Setting HDMI input for profile: $profile_path (placeholder)"
+
+  # Offsets and values based on the RT4K profile structure
+  local header_size=128                # Header size in bytes
+  local input_source_offset=22505      # Offset in data section (excluding header)
+  local total_input_offset=$((header_size + input_source_offset))  # Total offset in file
+
+  local input_source_hdmi_value=0      # Value representing HDMI input (from definitions)
+
+  # Write the HDMI input value at the specified offset
+  printf "%02x" "$input_source_hdmi_value" | xxd -r -p | dd of="$profile_path" bs=1 seek="$total_input_offset" count=1 conv=notrunc status=none
+
+  # Read the data starting from offset 128 to the end of the file
+  local crc_data_hex
+  crc_data_hex=$(dd if="$profile_path" bs=1 skip=128 status=none | xxd -p -c 256 | tr -d '\n')
+
+  # Calculate the CRC16 using the provided algorithm
+  local crc
+  crc=$(crc16 "$crc_data_hex")
+
+  # Prepare the CRC bytes in little-endian order
+  local crc_low
+  local crc_high
+  crc_low=$(printf "%02x" $((crc & 0xFF)))
+  crc_high=$(printf "%02x" $(((crc >> 8) & 0xFF)))
+
+  # Combine CRC bytes and two zero bytes
+  printf "%s%s0000" "$crc_low" "$crc_high" | xxd -r -p | dd of="$profile_path" bs=1 seek=32 count=4 conv=notrunc status=none
+}
+
+# CRC16 calculation function in Bash (as per provided C code)
+crc16() {
+  local data_hex="$1"
+  local crc=0
+  local data_len=${#data_hex}
+  local index t_dat crc_index
+
+  # CRC table as per the provided C code
+  local crc_table=(
+    0x0000 0x1021 0x2042 0x3063
+    0x4084 0x50a5 0x60c6 0x70e7
+    0x8108 0x9129 0xa14a 0xb16b
+    0xc18c 0xd1ad 0xe1ce 0xf1ef
+  )
+
+  # Process each byte (represented as two hex characters)
+  for (( index=0; index<data_len; index+=2 )); do
+    # Get the current byte value
+    t_dat=$(( 0x${data_hex:$index:2} ))
+
+    # First iteration
+    crc_index=$(( (crc >> 12) ^ (t_dat >> 4) ))
+    crc=$(( ${crc_table[crc_index & 0x0F]} ^ ( (crc << 4) & 0xFFFF ) ))
+
+    # Second iteration
+    crc_index=$(( (crc >> 12) ^ (t_dat & 0x0F) ))
+    crc=$(( ${crc_table[crc_index & 0x0F]} ^ ( (crc << 4) & 0xFFFF ) ))
+  done
+
+  # Return the lower 16 bits of crc
+  echo $(( crc & 0xFFFF ))
 }
 
 # Function to process cores
@@ -259,7 +324,9 @@ process_cores() {
       if [ "$FORCE" -eq 1 ]; then
         log "Overwriting existing profile for ${core_name}"
         if cp "$base_profile_to_use" "$dest_profile"; then
-          set_hdmi_input "$dest_profile"
+          if [ "$SET_HDMI_INPUT" -eq 1 ]; then
+            set_hdmi_input "$dest_profile"
+          fi
           overwritten_profiles=$((overwritten_profiles + 1))
         else
           echo "Error: Failed to overwrite profile for ${core_name}"
@@ -272,7 +339,9 @@ process_cores() {
     else
       log "Creating profile for ${core_name}"
       if cp "$base_profile_to_use" "$dest_profile"; then
-        set_hdmi_input "$dest_profile"
+        if [ "$SET_HDMI_INPUT" -eq 1 ]; then
+          set_hdmi_input "$dest_profile"
+        fi
         created_profiles=$((created_profiles + 1))
       else
         echo "Error: Failed to create profile for ${core_name}"
@@ -322,7 +391,9 @@ process_additional_arcade_profiles() {
       if [ "$FORCE" -eq 1 ]; then
         log "Overwriting existing profile for ${filename}"
         if cp "$base_profile_to_use" "$dest_profile"; then
-          set_hdmi_input "$dest_profile"
+          if [ "$SET_HDMI_INPUT" -eq 1 ]; then
+            set_hdmi_input "$dest_profile"
+          fi
           overwritten_profiles=$((overwritten_profiles + 1))
         else
           echo "Error: Failed to overwrite profile for ${filename}"
@@ -335,7 +406,9 @@ process_additional_arcade_profiles() {
     else
       log "Creating additional arcade profile for ${filename}"
       if cp "$base_profile_to_use" "$dest_profile"; then
-        set_hdmi_input "$dest_profile"
+        if [ "$SET_HDMI_INPUT" -eq 1 ]; then
+          set_hdmi_input "$dest_profile"
+        fi
         created_profiles=$((created_profiles + 1))
       else
         echo "Error: Failed to create profile for ${filename}"
@@ -373,7 +446,9 @@ additional_handling() {
     if [ "$FORCE" -eq 1 ]; then
       log "Overwriting Menu.rt4 profile"
       if cp "$PRF_ARCADE" "$dest_profile"; then
-        set_hdmi_input "$dest_profile"
+        if [ "$SET_HDMI_INPUT" -eq 1 ]; then
+          set_hdmi_input "$dest_profile"
+        fi
         overwritten_profiles=$((overwritten_profiles + 1))
       else
         echo "Error: Failed to overwrite Menu.rt4 profile"
@@ -386,7 +461,9 @@ additional_handling() {
   else
     log "Creating Menu.rt4 profile"
     if cp "$PRF_ARCADE" "$dest_profile"; then
-      set_hdmi_input "$dest_profile"
+      if [ "$SET_HDMI_INPUT" -eq 1 ]; then
+        set_hdmi_input "$dest_profile"
+      fi
       created_profiles=$((created_profiles + 1))
     else
       echo "Error: Failed to create Menu.rt4 profile"

--- a/tools/set_hdmi_input_python/set_hdmi_input.py
+++ b/tools/set_hdmi_input_python/set_hdmi_input.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import struct
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: set_hdmi_input.py <profile_file>")
+        sys.exit(1)
+    profile_file = sys.argv[1]
+
+    # Constants based on your Bash script
+    header_size = 128                # Header size in bytes
+    input_source_offset = 22505      # Offset in data section (excluding header)
+    total_input_offset = header_size + input_source_offset
+
+    input_source_hdmi_value = 0      # Value representing HDMI input
+
+    try:
+        with open(profile_file, 'r+b') as f:
+            # Set the HDMI input value at the specified offset
+            f.seek(total_input_offset)
+            f.write(bytes([input_source_hdmi_value]))
+
+            # Read the data starting from offset 128 to the end of the file
+            f.seek(header_size)
+            data = f.read()
+
+            # Calculate the CRC16 using the provided algorithm
+            crc = calculate_crc16(data)
+
+            # Prepare the CRC bytes in little-endian order
+            crc_low = crc & 0xFF
+            crc_high = (crc >> 8) & 0xFF
+
+            # Write the CRC back into the header at offset 32
+            f.seek(32)
+            f.write(bytes([crc_low, crc_high, 0x00, 0x00]))  # Append two zero bytes
+
+    except Exception as e:
+        print(f"Error processing file {profile_file}: {e}")
+        sys.exit(1)
+
+def calculate_crc16(data):
+    crc = 0
+
+    # CRC table as per the provided C code
+    crc_table = [
+        0x0000, 0x1021, 0x2042, 0x3063,
+        0x4084, 0x50A5, 0x60C6, 0x70E7,
+        0x8108, 0x9129, 0xA14A, 0xB16B,
+        0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
+    ]
+
+    for byte in data:
+        t_dat = byte
+
+        # First iteration
+        crc_index = ((crc >> 12) ^ (t_dat >> 4)) & 0x0F
+        crc = crc_table[crc_index] ^ ((crc << 4) & 0xFFFF)
+
+        # Second iteration
+        crc_index = ((crc >> 12) ^ (t_dat & 0x0F)) & 0x0F
+        crc = crc_table[crc_index] ^ ((crc << 4) & 0xFFFF)
+
+    return crc & 0xFFFF
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implemented the HDMI input override feature:
- Added `--set-hdmi-input` option to set HDMI input for all generated profiles.
- If you have python3 installed it will use it (fast) else it will override the input using pure bash scripting (slow)
- Updated `README.md` to reflect new HDMI override feature, options, and examples.
- Clarified README for use case of this script and DV1/RT4K behaviors
- Minor code fixes for improved reliability and verbose logging.