### PR TITLE
Feature/arcade use setname instead of zip name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ By scanning your MiSTer directories—either locally or remotely via SSH—for c
 
 - **Automated Profile Generation**: Scans MiSTer core directories and creates corresponding `.rt4` profiles.
 - **Supports Multiple Core Types**: Handles console, arcade, computer, and utility cores.
+- **Arcade Core Profiles from `.mra` Files**: Automatically generates arcade profiles based on the `<setname>` field in `.mra` files from the `/media/fat/_Arcade/` directory. This ensures accurate profile names matching the core’s expected setname.
 - **SSH Remote Retrieval**: Optionally retrieves core names from a remote MiSTer device via SSH, eliminating the need to remove the SD card.
 - **Default MiSTer Path and SSH User**: Assumes default MiSTer path `/media/fat/` and SSH user `root` if not specified.
 - **Customizable Base Profiles**: Allows you to specify base profiles for different core types.


### PR DESCRIPTION
# 🚀 New Version Available: MiSTer RT4K DV1 Profiles Generator

### What's New?
- **Arcade Profiles Improved**: Arcade profiles are now created based on the **set name** (`<setname>`) from `.mra` files, rather than the zip name. This approach is more accurate and aligns better with the DV1 information received by MiSTer. 

A huge shoutout and thanks to **TheJesusFish** for his help and thorough testing of this new feature! 🙌