### PR TITLE
Fix CDi profile renaming to cd-i (Issue #15)

### DIFF
--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -184,6 +184,7 @@ declare -a renaming_rules=(
   "GameboyColor.rt4 GBC.rt4"
   "PocketChallengeV2.rt4 PocketChalleng.rt4"
   "WonderSwanColor.rt4 WonderSwanColo.rt4"
+  "CDi.rt4 cd-i.rt4"
 )
 
 # Replace associative array with two regular arrays


### PR DESCRIPTION
## Summary

This PR fixes Issue #15 by adding the correct renaming rule for the CDi profile. The issue was that the RBF core is named "CDi" but the actual setname should be "cd-i".

## Problem

The CDi core creates a profile named `CDi.rt4`, but the correct setname according to the core specifications should be `cd-i.rt4`.

## Solution

Added a new renaming rule to the `renaming_rules` array:
```bash
"CDi.rt4 cd-i.rt4"
```

This ensures that:
1. When the script processes the CDi core, it initially creates `CDi.rt4`
2. During the additional_handling phase, it automatically renames `CDi.rt4` to `cd-i.rt4`
3. The final profile matches the expected setname format

## Changes Made

- Added `"CDi.rt4 cd-i.rt4"` to the `renaming_rules` array in `generate_rt4k_mister_dv1_profiles.sh`

## Testing

- ✅ Script syntax validation passes (`bash -n`)
- ✅ Renaming rule follows the same pattern as existing rules
- ✅ Change is minimal and focused

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closes

Fixes #15

This fix ensures that the CDi profile will have the correct filename that matches the expected setname format used by the RetroTINK 4K.