### PR TITLE
Fix issue #21: Handle empty IGNORE_CORES_ARRAY properly

### DIFF
--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -209,11 +209,14 @@ fi
 # Function to check if a core should be ignored
 is_core_ignored() {
   local core_name="$1"
-  for ignored_core in "${IGNORE_CORES_ARRAY[@]}"; do
-    if [[ "$core_name" == "$ignored_core" ]]; then
-      return 0  # Core is ignored
-    fi
-  done
+  # Check if array has elements before iterating
+  if [ ${#IGNORE_CORES_ARRAY[@]} -gt 0 ]; then
+    for ignored_core in "${IGNORE_CORES_ARRAY[@]}"; do
+      if [[ "$core_name" == "$ignored_core" ]]; then
+        return 0  # Core is ignored
+      fi
+    done
+  fi
   return 1  # Core is not ignored
 }
 


### PR DESCRIPTION
## Summary
Fixes #21 - Script no longer fails when no value is provided for `--ignore-cores` parameter.

## Problem
The script was failing with an "unbound variable" error when no `--ignore-cores` parameter was provided:
```
./generate_rt4k_mister_dv1_profiles.sh: line 210: IGNORE_CORES_ARRAY[@]: unbound variable
```

This happened because the script uses `set -eu` (strict mode) and attempted to iterate over `"${IGNORE_CORES_ARRAY[@]}"` when the array was empty.

## Solution
Modified the `is_core_ignored()` function to check if the array has elements before iterating:
- Added `if [ ${#IGNORE_CORES_ARRAY[@]} -gt 0 ]; then` check before the loop
- When array is empty, function returns 1 (core is not ignored) without attempting iteration

## Testing
✅ Script now works without `--ignore-cores` parameter  
✅ Script continues to work with `--ignore-cores` parameter  
✅ No more "unbound variable" errors  

## Expected Behavior
- When no `--ignore-cores` is provided: script continues with no cores ignored
- When `--ignore-cores` is provided: script ignores specified cores as before

Closes #21