### PR TITLE
Update for 1.96 and fix unbound variable error

### DIFF
--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -212,7 +212,7 @@ is_core_ignored() {
   # Check if array has elements before iterating
   # Use [@]:-  to handle empty arrays with set -u
   if [ -n "${IGNORE_CORES_ARRAY:-}" ] && [ ${#IGNORE_CORES_ARRAY[@]} -gt 0 ]; then
-    for ignored_core in "${IGNORE_CORES_ARRAY[@]}"; do
+    for ignored_core in "${IGNORE_CORES_ARRAY[@]:-}"; do
       if [[ "$core_name" == "$ignored_core" ]]; then
         return 0  # Core is ignored
       fi

--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -211,13 +211,16 @@ is_core_ignored() {
   local core_name="$1"
   # Check if array has elements before iterating
   # Use [@]:-  to handle empty arrays with set -u
-  if [ ${#IGNORE_CORES_ARRAY[@]:-0} -gt 0 ]; then
-    for ignored_core in "${IGNORE_CORES_ARRAY[@]:-}"; do
+  if [ -n "${IGNORE_CORES_ARRAY:-}" ] && [ ${#IGNORE_CORES_ARRAY[@]} -gt 0 ]; then
+    echo found ignored cores
+    for ignored_core in "${IGNORE_CORES_ARRAY[@]}"; do
       if [[ "$core_name" == "$ignored_core" ]]; then
+        echo ignoring core $core_name
         return 0  # Core is ignored
       fi
     done
   fi
+  echo not ignored $1
   return 1  # Core is not ignored
 }
 

--- a/generate_rt4k_mister_dv1_profiles.sh
+++ b/generate_rt4k_mister_dv1_profiles.sh
@@ -212,15 +212,12 @@ is_core_ignored() {
   # Check if array has elements before iterating
   # Use [@]:-  to handle empty arrays with set -u
   if [ -n "${IGNORE_CORES_ARRAY:-}" ] && [ ${#IGNORE_CORES_ARRAY[@]} -gt 0 ]; then
-    echo found ignored cores
     for ignored_core in "${IGNORE_CORES_ARRAY[@]}"; do
       if [[ "$core_name" == "$ignored_core" ]]; then
-        echo ignoring core $core_name
         return 0  # Core is ignored
       fi
     done
   fi
-  echo not ignored $1
   return 1  # Core is not ignored
 }
 

--- a/profiles_config.sh
+++ b/profiles_config.sh
@@ -1,8 +1,8 @@
 # profiles_config.sh
 
 # Set Base Profiles (Console, Arcade)
-PRF_CONSOLE="${RT4K}profile/CRT TV and PVM Emulation by Kuro Houou/JVC D-Series-D200 - 4K HDR.rt4"
-PRF_ARCADE="${RT4K}profile/CRT TV and PVM Emulation by Kuro Houou/JVC D-Series-D200 - 4K HDR.rt4"
+PRF_CONSOLE="${RT4K}profile/_CRT Emulation/CRT TV and PVM Emulation by Kuro Houou/JVC D-Series-D200 - 4K HDR.rt4"
+PRF_ARCADE="${RT4K}profile/_CRT Emulation/CRT TV and PVM Emulation by Kuro Houou/JVC D-Series-D200 - 4K HDR.rt4"
 
 # Cores to ignore (comma-separated list)
 # Example: IGNORE_CORES_FROM_CONFIG="Menu,TurboGrafx16,GameBoy"


### PR DESCRIPTION
It looks like 1.96 changed the locations of some of the profiles listed as base profiles.  I don't see any profiles named RGBL and I wasn't sure which ones would be reasonable to use instead, so the per-core override variable examples (currently commented out) will need to be updated separately.

I also made a change to line 214 in `generate_rt4k_mister_dv1_profiles.sh`, though I'm not sure it's quite the right way to go about it.  But, what I was seeing without that change (on macOS 26.1 with Bash 5.3.3) was:

`line 214: IGNORE_CORES_ARRAY: unbound variable`

From doing some testing, it seemed to be specifically caused by assigning a default value to the length of the variable there.  I can replicate the issue by doing:

```
$ export TESTVAR=testvalue
$ echo "${TESTVAR}"
testvalue
$ echo "${#TESTVAR}"
9
$ echo "${#TESTVAR:-0}"
bash: ${#TESTVAR:-0}: bad substitution
```